### PR TITLE
Remove "A" suffix from all string-related win32 API function names

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -43,8 +43,8 @@ char *__fastcall GetErr(int error_code)
 	}
 	else
 	{
-		if ( !SErrGetErrorStr(error_code, sz_error_buf, 256) && !FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, v1, 0x400u, sz_error_buf, 0x100u, NULL) )
-			wsprintfA(sz_error_buf, "unknown error 0x%08x", v1);
+		if ( !SErrGetErrorStr(error_code, sz_error_buf, 256) && !FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, v1, 0x400u, sz_error_buf, 0x100u, NULL) )
+			wsprintf(sz_error_buf, "unknown error 0x%08x", v1);
 	}
 	v4 = strlen(sz_error_buf);
 	for ( i = &sz_error_buf[v4-1]; v4 > 0; *i = 0 )
@@ -222,10 +222,10 @@ void __fastcall MsgBox(char *pszFmt, va_list va)
 {
 	char Text[256]; // [esp+0h] [ebp-100h]
 
-	wvsprintfA(Text, pszFmt, va);
+	wvsprintf(Text, pszFmt, va);
 	if ( ghMainWnd )
 		SetWindowPos(ghMainWnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOACTIVATE|SWP_NOMOVE|SWP_NOSIZE);
-	MessageBoxA(ghMainWnd, Text, "ERROR", MB_TASKMODAL|MB_ICONHAND);
+	MessageBox(ghMainWnd, Text, "ERROR", MB_TASKMODAL|MB_ICONHAND);
 }
 
 void __cdecl FreeDlg()
@@ -253,7 +253,7 @@ void DrawDlg(char *pszFmt, ...)
 	va_list arglist; // [esp+10Ch] [ebp+Ch]
 
 	va_start(arglist, pszFmt);
-	wvsprintfA(text, pszFmt, arglist);
+	wvsprintf(text, pszFmt, arglist);
 	SDrawMessageBox(text, "Diablo", MB_TASKMODAL|MB_ICONEXCLAMATION);
 }
 
@@ -326,8 +326,8 @@ void __fastcall ErrDlg(int template_id, int error_code, char *log_file_path, int
 	if ( v7 )
 		v6 = v7 + 1;
 	v8 = GetErr(v4);
-	wsprintfA((LPSTR)dwInitParam, "%s\nat: %s line %d", v8, v6, log_line_nr);
-	if ( DialogBoxParamA(ghInst, MAKEINTRESOURCE(v5), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)dwInitParam) == -1 )
+	wsprintf((LPSTR)dwInitParam, "%s\nat: %s line %d", v8, v6, log_line_nr);
+	if ( DialogBoxParam(ghInst, MAKEINTRESOURCE(v5), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)dwInitParam) == -1 )
 		TermMsg("ErrDlg: %d", v5);
 	TermMsg(0);
 }
@@ -363,7 +363,7 @@ void __fastcall TextDlg(HWND hDlg, char *text)
 	v3 = hDlg;
 	center_window(hDlg);
 	if ( v2 )
-		SetDlgItemTextA(v3, 1000, v2);
+		SetDlgItemText(v3, 1000, v2);
 }
 
 void __fastcall ErrOkDlg(int template_id, int error_code, char *log_file_path, int log_line_nr)
@@ -382,8 +382,8 @@ void __fastcall ErrOkDlg(int template_id, int error_code, char *log_file_path, i
 	if ( v7 )
 		v4 = v7 + 1;
 	v8 = GetErr(v5);
-	wsprintfA((LPSTR)dwInitParam, "%s\nat: %s line %d", v8, v4, log_line_nr);
-	DialogBoxParamA(ghInst, MAKEINTRESOURCE(v6), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)dwInitParam);
+	wsprintf((LPSTR)dwInitParam, "%s\nat: %s line %d", v8, v4, log_line_nr);
+	DialogBoxParam(ghInst, MAKEINTRESOURCE(v6), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)dwInitParam);
 }
 
 void __fastcall FileErrDlg(char *error)
@@ -394,7 +394,7 @@ void __fastcall FileErrDlg(char *error)
 	FreeDlg();
 	if ( !v1 )
 		v1 = &empty_string;
-	if ( DialogBoxParamA(ghInst, MAKEINTRESOURCE(IDD_DIALOG3), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)v1) == -1 )
+	if ( DialogBoxParam(ghInst, MAKEINTRESOURCE(IDD_DIALOG3), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)v1) == -1 )
 		TermMsg("FileErrDlg");
 	TermMsg(0);
 }
@@ -405,7 +405,7 @@ void __fastcall DiskFreeDlg(char *error)
 
 	v1 = error;
 	FreeDlg();
-	if ( DialogBoxParamA(ghInst, MAKEINTRESOURCE(IDD_DIALOG7), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)v1) == -1 )
+	if ( DialogBoxParam(ghInst, MAKEINTRESOURCE(IDD_DIALOG7), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)v1) == -1 )
 		TermMsg("DiskFreeDlg");
 	TermMsg(0);
 }
@@ -415,7 +415,7 @@ bool __cdecl InsertCDDlg()
 	int v0; // edi
 
 	ShowCursor(1);
-	v0 = DialogBoxParamA(ghInst, MAKEINTRESOURCE(IDD_DIALOG9), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)&empty_string);
+	v0 = DialogBoxParam(ghInst, MAKEINTRESOURCE(IDD_DIALOG9), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)&empty_string);
 	if ( v0 == -1 )
 		TermMsg("InsertCDDlg");
 	ShowCursor(0);
@@ -428,7 +428,7 @@ void __fastcall DirErrorDlg(char *error)
 
 	v1 = error;
 	FreeDlg();
-	if ( DialogBoxParamA(ghInst, MAKEINTRESOURCE(IDD_DIALOG11), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)v1) == -1 )
+	if ( DialogBoxParam(ghInst, MAKEINTRESOURCE(IDD_DIALOG11), ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)v1) == -1 )
 		TermMsg("DirErrorDlg");
 	TermMsg(0);
 }

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -28,7 +28,7 @@ void __cdecl CaptureScreen()
 		CloseHandle(hObject);
 
 		if (!success)
-			DeleteFileA(FileName);
+			DeleteFile(FileName);
 
 		Sleep(300);
 		lpDDPalette->SetEntries(0, 0, 256, palette);
@@ -154,7 +154,7 @@ HANDLE __fastcall CaptureFile(char *dst_path)
 	}
 
 	sprintf(dst_path, "screen%02d.PCX", free_num);
-	return CreateFileA(dst_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	return CreateFile(dst_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 }
 
 void __fastcall RedPalette(PALETTEENTRY *pal)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -173,10 +173,10 @@ void __fastcall run_game_loop(int uMsg)
 	while ( gbRunGame )
 	{
 		diablo_color_cyc_logic();
-		if ( PeekMessageA(&msg, NULL, 0, 0, PM_NOREMOVE) )
+		if ( PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE) )
 		{
 			SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
-			while ( PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE) )
+			while ( PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
 			{
 				if ( msg.message == WM_QUIT )
 				{
@@ -185,7 +185,7 @@ void __fastcall run_game_loop(int uMsg)
 					break;
 				}
 				TranslateMessage(&msg);
-				DispatchMessageA(&msg);
+				DispatchMessage(&msg);
 			}
 			if ( !gbRunGame || (v7 = 1, !nthread_has_500ms_passed()) )
 				v7 = 0;
@@ -274,7 +274,7 @@ void __cdecl free_game()
 bool __cdecl diablo_get_not_running()
 {
 	SetLastError(0);
-	CreateEventA(NULL, FALSE, FALSE, "DiabloEvent");
+	CreateEvent(NULL, FALSE, FALSE, "DiabloEvent");
 	return GetLastError() != ERROR_ALREADY_EXISTS;
 }
 
@@ -294,7 +294,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		ErrOkDlg(IDD_DIALOG10, 0, "C:\\Src\\Diablo\\Source\\DIABLO.CPP", 877);
 	if ( ReadOnlyTest() )
 	{
-		if ( !GetModuleFileNameA(ghInst, Filename, 0x104u) )
+		if ( !GetModuleFileName(ghInst, Filename, 0x104u) )
 			*Filename = '\0';
 		DirErrorDlg(Filename);
 	}
@@ -501,7 +501,7 @@ BOOL __fastcall diablo_find_window(LPCSTR lpClassName)
 	HWND v3; // eax
 	HWND v4; // edi
 
-	result = FindWindowA(lpClassName, 0);
+	result = FindWindow(lpClassName, 0);
 	v2 = result;
 	if ( !result )
 		return 0;
@@ -538,8 +538,8 @@ void __fastcall diablo_reload_process(HMODULE hModule)
 	memset(Filename + 1, 0, sizeof(Filename) - 1);
 //	*(_WORD *)&Filename[257] = 0;
 //	Filename[259] = 0;
-	GetModuleFileNameA(hModule, Filename, 0x104u);
-	wsprintfA(Name, "Reload-%s", Filename);
+	GetModuleFileName(hModule, Filename, 0x104u);
+	wsprintf(Name, "Reload-%s", Filename);
 	for ( i = Name; *i; ++i )
 	{
 		if ( *i == '\\' )
@@ -549,7 +549,7 @@ void __fastcall diablo_reload_process(HMODULE hModule)
 	dwSize = sinf.dwPageSize;
 	if ( sinf.dwPageSize < 4096 )
 		dwSize = 4096;
-	hMap = CreateFileMappingA((HANDLE)0xFFFFFFFF, NULL, SEC_COMMIT|PAGE_READWRITE, 0, dwSize, Name);
+	hMap = CreateFileMapping((HANDLE)0xFFFFFFFF, NULL, SEC_COMMIT|PAGE_READWRITE, 0, dwSize, Name);
 	v3 = GetLastError() != ERROR_ALREADY_EXISTS;
 	if ( hMap )
 	{
@@ -563,7 +563,7 @@ void __fastcall diablo_reload_process(HMODULE hModule)
 				v4[1] = 0;
 				memset(&si, 0, sizeof(si));
 				si.cb = sizeof(si);
-				CreateProcessA(Filename, NULL, NULL, NULL, FALSE, CREATE_NEW_PROCESS_GROUP, NULL, NULL, &si, &pi);
+				CreateProcess(Filename, NULL, NULL, NULL, FALSE, CREATE_NEW_PROCESS_GROUP, NULL, NULL, &si, &pi);
 				WaitForInputIdle(pi.hProcess, 0xFFFFFFFF);
 				CloseHandle(pi.hThread);
 				CloseHandle(pi.hProcess);
@@ -1194,13 +1194,13 @@ void __fastcall diablo_hotkey_msg(int dwMsg)
 	v1 = dwMsg;
 	if ( gbMaxPlayers != 1 )
 	{
-		if ( !GetModuleFileNameA(ghInst, Filename, 0x104u) )
+		if ( !GetModuleFileName(ghInst, Filename, 0x104u) )
 			TermMsg("Can't get program name");
 		v2 = strrchr(Filename, '\\');
 		if ( v2 )
 			*v2 = 0;
 		strcat(Filename, "\\Diablo.ini");
-		GetPrivateProfileStringA("NetMsg", spszMsgKeyTbl[v1], spszMsgTbl[v1], ReturnedString, 0x50u, Filename);
+		GetPrivateProfileString("NetMsg", spszMsgKeyTbl[v1], spszMsgTbl[v1], ReturnedString, 0x50u, Filename);
 		NetSendCmdString(-1, ReturnedString);
 	}
 }

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -103,7 +103,7 @@ void __cdecl dthread_start()
 
 	if ( gbMaxPlayers != 1 )
 	{
-		sghWorkToDoEvent = CreateEventA(NULL, TRUE, FALSE, NULL);
+		sghWorkToDoEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 		if ( !sghWorkToDoEvent )
 		{
 			v0 = GetLastErr();

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -168,7 +168,7 @@ HRESULT __fastcall dx_DirectDrawCreate(GUID *guid, IDirectDraw **DD, void *unkno
 	v8 = guid;
 	if ( !ghDiabMod )
 	{
-		ghDiabMod = LoadLibraryA("ddraw.dll");
+		ghDiabMod = LoadLibrary("ddraw.dll");
 		if ( !ghDiabMod )
 		{
 			v4 = GetLastError();

--- a/Source/fault.cpp
+++ b/Source/fault.cpp
@@ -118,7 +118,7 @@ void __fastcall exception_hex_format(BYTE *ptr, unsigned int numBytes)
 
 void __fastcall exception_unknown_module(LPCVOID lpAddress, LPSTR lpModuleName, int iMaxLength, int *sectionNum, int *sectionOffset)
 {
-	lstrcpynA(lpModuleName, "*unknown*", iMaxLength);
+	lstrcpyn(lpModuleName, "*unknown*", iMaxLength);
 	*sectionNum = 0;
 	*sectionOffset = 0;
 
@@ -128,11 +128,11 @@ void __fastcall exception_unknown_module(LPCVOID lpAddress, LPSTR lpModuleName, 
 
 	PIMAGE_DOS_HEADER dosHeader = (PIMAGE_DOS_HEADER)memInfo.AllocationBase;
 	if ( !memInfo.AllocationBase )
-		dosHeader = (PIMAGE_DOS_HEADER)GetModuleHandleA(0);
+		dosHeader = (PIMAGE_DOS_HEADER)GetModuleHandle(0);
 
-	if (!GetModuleFileNameA((HMODULE)dosHeader, lpModuleName, iMaxLength))
+	if (!GetModuleFileName((HMODULE)dosHeader, lpModuleName, iMaxLength))
 	{
-		lstrcpynA(lpModuleName, "*unknown*", iMaxLength);
+		lstrcpyn(lpModuleName, "*unknown*", iMaxLength);
 		return;
 	}
 
@@ -222,13 +222,13 @@ char *__fastcall exception_get_error_type(DWORD dwMessageId, LPSTR lpString1, DW
 	CASE_EXCEPTION(v4, SINGLE_STEP);
 	CASE_EXCEPTION(v4, ACCESS_VIOLATION);
 	default:
-		HMODULE ntdll = GetModuleHandleA("NTDLL.DLL");
-		if (!FormatMessageA(FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS, ntdll, dwMessageId, 0, lpString1, nSize, NULL))
+		HMODULE ntdll = GetModuleHandle("NTDLL.DLL");
+		if (!FormatMessage(FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS, ntdll, dwMessageId, 0, lpString1, nSize, NULL))
 		{
 			v4 = "*unknown*";
 		}
 	}
-	lstrcpynA(lpString1, v4, nSize);
+	lstrcpyn(lpString1, v4, nSize);
 	return lpString1;
 }
 

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -24,12 +24,12 @@ void __cdecl interface_msg_pump()
 {
 	MSG Msg; // [esp+8h] [ebp-1Ch]
 
-	while ( PeekMessageA(&Msg, NULL, 0, 0, PM_REMOVE) )
+	while ( PeekMessage(&Msg, NULL, 0, 0, PM_REMOVE) )
 	{
 		if ( Msg.message != WM_QUIT )
 		{
 			TranslateMessage(&Msg);
-			DispatchMessageA(&Msg);
+			DispatchMessage(&Msg);
 		}
 	}
 }

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -93,12 +93,12 @@ void *__cdecl log_create()
 
 	if ( log_not_created )
 	{
-		if ( GetModuleFileNameA(0, Filename, 0x104u) && (v0 = strrchr(Filename, '\\')) != 0 )
+		if ( GetModuleFileName(0, Filename, 0x104u) && (v0 = strrchr(Filename, '\\')) != 0 )
 			v0[1] = 0;
 		else
 			Filename[0] = 0;
 		pcbBuffer = 32;
-		if ( !GetUserNameA(Buffer, &pcbBuffer) )
+		if ( !GetUserName(Buffer, &pcbBuffer) )
 			Buffer[0] = 0;
 		log_get_version(&file_info);
 		_snprintf(
@@ -114,7 +114,7 @@ void *__cdecl log_create()
 	v1 = (void *)-1;
 	for ( pcbBuffer = log_not_created == 0; (signed int)pcbBuffer < 2; ++pcbBuffer )
 	{
-		v2 = CreateFileA(FileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+		v2 = CreateFile(FileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 		v1 = v2;
 		if ( v2 != (HANDLE)-1 )
 		{
@@ -149,14 +149,14 @@ void __fastcall log_get_version(VS_FIXEDFILEINFO *file_info)
 
 	v9 = file_info;
 	memset(file_info, 0, 0x34u);
-	if ( GetModuleFileNameA(0, Filename, 0x104u) )
+	if ( GetModuleFileName(0, Filename, 0x104u) )
 	{
-		v1 = GetFileVersionInfoSizeA(Filename, &dwHandle);
+		v1 = GetFileVersionInfoSize(Filename, &dwHandle);
 		v2 = v1;
 		if ( v1 )
 		{
 			v3 = VirtualAlloc(0, v1, 0x1000u, 4u);
-			if ( GetFileVersionInfoA(Filename, 0, v2, v3) && VerQueryValueA(v3, "\\", &lpBuffer, &puLen) )
+			if ( GetFileVersionInfo(Filename, 0, v2, v3) && VerQueryValue(v3, "\\", &lpBuffer, &puLen) )
 			{
 				v4 = puLen;
 				if ( puLen >= 0x34 )
@@ -203,7 +203,7 @@ void __cdecl log_dump_computer_info()
 
 	GetLocalTime(&SystemTime);
 	pcbBuffer = 64;
-	if ( !GetUserNameA(Buffer, &pcbBuffer) )
+	if ( !GetUserName(Buffer, &pcbBuffer) )
 		Buffer[0] = 0;
 	log_get_version(&file_info);
 	log_printf(

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -45,12 +45,12 @@ void __fastcall play_movie(char *pszMovie, BOOL user_can_close)
 			{
 				if ( !gbActive || v6 && !movie_playing )
 					break;
-				while ( PeekMessageA(&Msg, NULL, 0, 0, PM_REMOVE) )
+				while ( PeekMessage(&Msg, NULL, 0, 0, PM_REMOVE) )
 				{
 					if ( Msg.message != WM_QUIT )
 					{
 						TranslateMessage(&Msg);
-						DispatchMessageA(&Msg);
+						DispatchMessage(&Msg);
 					}
 				}
 				//_LOBYTE(v4) = SVidPlayContinue();

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -38,14 +38,14 @@ bool __fastcall mpqapi_set_hidden(char *pszArchive, bool hidden)
 
 	v2 = pszArchive;
 	v3 = hidden;
-	v4 = GetFileAttributesA(pszArchive);
+	v4 = GetFileAttributes(pszArchive);
 	if ( v4 == -1 )
 		return GetLastError() == ERROR_FILE_NOT_FOUND;
 	v6 = v3 != 0 ? FILE_ATTRIBUTE_SYSTEM|FILE_ATTRIBUTE_HIDDEN : 0;
 	if ( v4 == v6 )
 		result = 1;
 	else
-		result = SetFileAttributesA(v2, v6);
+		result = SetFileAttributes(v2, v6);
 	return result;
 }
 
@@ -63,7 +63,7 @@ void __fastcall mpqapi_store_creation_time(char *pszArchive, int dwChar)
 	if ( gbMaxPlayers != 1 )
 	{
 		mpqapi_reg_load_modification_time(dst, 160);
-		v4 = FindFirstFileA(v3, &FindFileData);
+		v4 = FindFirstFile(v3, &FindFileData);
 		if ( v4 != (HANDLE)-1 )
 		{
 			FindClose(v4);
@@ -561,10 +561,10 @@ bool __fastcall mpqapi_open_archive(char *pszArchive, bool hidden, int dwChar) /
 		return 0;
 	v6 = (unsigned char)gbMaxPlayers > 1u ? FILE_FLAG_WRITE_THROUGH : 0;
 	save_archive_open = 0;
-	sghArchive = CreateFileA(v3, GENERIC_READ|GENERIC_WRITE, 0, NULL, OPEN_EXISTING, v6, NULL);
+	sghArchive = CreateFile(v3, GENERIC_READ|GENERIC_WRITE, 0, NULL, OPEN_EXISTING, v6, NULL);
 	if ( sghArchive == (HANDLE)-1 )
 	{
-		sghArchive = CreateFileA(lpFileName, GENERIC_READ|GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, v6 | (v4 != 0 ? FILE_ATTRIBUTE_SYSTEM|FILE_ATTRIBUTE_HIDDEN : 0), NULL);
+		sghArchive = CreateFile(lpFileName, GENERIC_READ|GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, v6 | (v4 != 0 ? FILE_ATTRIBUTE_SYSTEM|FILE_ATTRIBUTE_HIDDEN : 0), NULL);
 		if ( sghArchive == (HANDLE)-1 )
 			return 0;
 		save_archive_open = 1;
@@ -702,7 +702,7 @@ void __fastcall mpqapi_store_modified_time(char *pszArchive, int dwChar)
 	if ( gbMaxPlayers != 1 )
 	{
 		mpqapi_reg_load_modification_time(dst, 160);
-		v4 = FindFirstFileA(v3, &FindFileData);
+		v4 = FindFirstFile(v3, &FindFileData);
 		if ( v4 != (HANDLE)-1 )
 		{
 			FindClose(v4);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -22,8 +22,8 @@ void __cdecl pfile_init_save_directory()
 {
 	char Buffer[260]; // [esp+4h] [ebp-104h]
 
-	if ( GetWindowsDirectoryA(Buffer, 0x104u)
-	  && (pfile_check_available_space(Buffer), GetModuleFileNameA(ghInst, Buffer, 0x104u)) )
+	if ( GetWindowsDirectory(Buffer, 0x104u)
+	  && (pfile_check_available_space(Buffer), GetModuleFileName(ghInst, Buffer, 0x104u)) )
 	{
 		pfile_check_available_space(Buffer);
 	}
@@ -58,7 +58,7 @@ void __fastcall pfile_check_available_space(char *pszDir)
 			break;
 		}
 	}
-	v4 = GetDiskFreeSpaceA(v1, &SectorsPerCluster, &BytesPerSector, &NumberOfFreeClusters, &TotalNumberOfClusters);
+	v4 = GetDiskFreeSpace(v1, &SectorsPerCluster, &BytesPerSector, &NumberOfFreeClusters, &TotalNumberOfClusters);
 	if ( !v4 )
 		goto LABEL_12;
 	if ( (signed __int64)(BytesPerSector * (unsigned __int64)SectorsPerCluster * NumberOfFreeClusters) < 0xA00000 )
@@ -161,7 +161,7 @@ void __fastcall pfile_get_save_path(char *pszBuf, int dwBufSize, int save_num)
 	v4 = "\\multi_%d.sv";
 	if ( (unsigned char)gbMaxPlayers <= 1u )
 		v4 = "\\single_%d.sv";
-	v5 = GetModuleFileNameA(ghInst, pszBuf, 0x104u);
+	v5 = GetModuleFileName(ghInst, pszBuf, 0x104u);
 	v6 = strrchr(v3, '\\');
 	if ( v6 )
 		*v6 = 0;
@@ -332,14 +332,14 @@ bool __stdcall pfile_ui_set_hero_infos(void (__stdcall *ui_add_hero_info)(_uiher
 						if ( (unsigned int)save_num >= MAX_CHARACTERS )
 							goto LABEL_13;
 					}
-					if ( CopyFileA(FileName, NewFileName, 1) )
+					if ( CopyFile(FileName, NewFileName, 1) )
 					{
 						SRegSaveString("Diablo\\Converted", v1, 0, NewFileName);
-						v4 = GetFileAttributesA(NewFileName);
+						v4 = GetFileAttributes(NewFileName);
 						if ( v4 != -1 )
 						{
 							_LOBYTE(v4) = v4 & 0xF9;
-							SetFileAttributesA(NewFileName, v4);
+							SetFileAttributes(NewFileName, v4);
 						}
 					}
 				}
@@ -386,7 +386,7 @@ char *__fastcall GetSaveDirectory(char *dst, int dst_size, int save_num)
 	if ( (unsigned char)gbMaxPlayers <= 1u )
 	{
 		v4 = "\\single_%d.sv";
-		v5 = GetModuleFileNameA(ghInst, dst, 0x104u);
+		v5 = GetModuleFileName(ghInst, dst, 0x104u);
 		v6 = strrchr(v3, '\\');
 		if ( v6 )
 			*v6 = '\0';
@@ -394,7 +394,7 @@ char *__fastcall GetSaveDirectory(char *dst, int dst_size, int save_num)
 	else
 	{
 		v4 = "\\dlinfo_%d.drv";
-		v5 = GetWindowsDirectoryA(dst, 0x104u);
+		v5 = GetWindowsDirectory(dst, 0x104u);
 	}
 	if ( !v5 )
 		TermMsg("Unable to get save directory");
@@ -446,7 +446,7 @@ bool __fastcall pfile_read_hero(void *archive, PkPlayerStruct *pPack)
 				goto LABEL_11;
 			if ( (unsigned char)gbMaxPlayers > 1u )
 			{
-				GetComputerNameA(password, &nSize);
+				GetComputerName(password, &nSize);
 				if ( !SFileSetFilePointer(file, 0, 0, 0) )
 				{
 					//_LOBYTE(v8) = SFileReadFile(file, v6, v4, (unsigned long *)&dwBytes, 0);
@@ -619,7 +619,7 @@ bool __stdcall pfile_delete_save(_uiheroinfo *hero_info)
 	{
 		hero_names[v1][0] = 0;
 		pfile_get_save_path(FileName, 260, v1);
-		DeleteFileA(FileName);
+		DeleteFile(FileName);
 	}
 	return 1;
 }
@@ -880,7 +880,7 @@ char *__fastcall pfile_read(char *pszName, int *pdwLen)
 	{
 		if ( (unsigned char)gbMaxPlayers > 1u )
 		{
-			GetComputerNameA(password, &nSize);
+			GetComputerName(password, &nSize);
 			if ( SFileSetFilePointer(file, 0, 0, 0) )
 				TermMsg("Unable to read save file");
 			//_LOBYTE(v11) = SFileReadFile(file, v9, *v2, (unsigned long *)&nread, 0);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2237,7 +2237,7 @@ void __fastcall StartNewLvl(int pnum, int fom, int lvl)
 	if ( pnum == myplr ) {
 		plr[pnum]._pmode = PM_NEWLVL;
 		plr[pnum]._pInvincible = TRUE;
-		PostMessageA(ghMainWnd, fom, 0, 0);
+		PostMessage(ghMainWnd, fom, 0, 0);
 		if ( gbMaxPlayers > 1 ) {
 			NetSendCmdParam2(TRUE, CMD_NEWLVL, fom, lvl);
 		}
@@ -2271,7 +2271,7 @@ void __fastcall RestartTownLvl(int pnum)
 		plr[v2]._pmode = PM_NEWLVL;
 		v4 = ghMainWnd;
 		plr[v2]._pInvincible = 1;
-		PostMessageA(v4, WM_DIABRETOWN, 0, 0);
+		PostMessage(v4, WM_DIABRETOWN, 0, 0);
 	}
 }
 
@@ -2301,7 +2301,7 @@ void __fastcall StartWarpLvl(int pnum, int pidx)
 		plr[v5]._pmode = PM_NEWLVL;
 		v6 = ghMainWnd;
 		plr[v5]._pInvincible = 1;
-		PostMessageA(v6, WM_DIABWARPLVL, 0, 0);
+		PostMessage(v6, WM_DIABWARPLVL, 0, 0);
 	}
 }
 // 679660: using guessed type char gbMaxPlayers;

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -10,7 +10,7 @@ bool __cdecl SystemSupported()
 	v0 = 0;
 	memset(&VersionInformation, 0, 0x94u);
 	VersionInformation.dwOSVersionInfoSize = 148;
-	if ( GetVersionExA(&VersionInformation)
+	if ( GetVersionEx(&VersionInformation)
 	  && VersionInformation.dwPlatformId == 2
 	  && VersionInformation.dwMajorVersion >= 5 )
 	{
@@ -26,7 +26,7 @@ bool __cdecl RestrictedTest()
 	char Buffer[260]; // [esp+4h] [ebp-104h]
 
 	v0 = 0;
-	if ( SystemSupported() && GetWindowsDirectoryA(Buffer, 0x104u) )
+	if ( SystemSupported() && GetWindowsDirectory(Buffer, 0x104u) )
 	{
 		strcat(Buffer, "\\Diablo1RestrictedTest.foo");
 		v2 = fopen(Buffer, "wt");
@@ -51,7 +51,7 @@ bool __cdecl ReadOnlyTest()
 	char Filename[260]; // [esp+4h] [ebp-104h]
 
 	v0 = 0;
-	if ( GetModuleFileNameA(ghInst, Filename, 0x104u) )
+	if ( GetModuleFileName(ghInst, Filename, 0x104u) )
 	{
 		v1 = strrchr(Filename, '\\');
 		if ( v1 )

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -3250,10 +3250,10 @@ void __cdecl DrawFPS()
 		}
 		if ( framerate > 99 )
 			framerate = 99;
-		wsprintfA(String, "%2d", framerate);
+		wsprintf(String, "%2d", framerate);
 		if ( !lpDDSPrimary->GetDC(&hdc) )
 		{
-			TextOutA(hdc, 0, 400, String, strlen(String));
+			TextOut(hdc, 0, 400, String, strlen(String));
 			lpDDSPrimary->ReleaseDC(hdc);
 		}
 	}

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -392,7 +392,7 @@ int __fastcall sound_DirectSoundCreate(GUID *guid, IDirectSound **DS, int always
 	v8 = guid;
 	if ( !hDsound_dll )
 	{
-		hDsound_dll = LoadLibraryA("dsound.dll");
+		hDsound_dll = LoadLibrary("dsound.dll");
 		if ( !hDsound_dll )
 		{
 			v4 = GetLastError();


### PR DESCRIPTION
In reference to this: https://github.com/diasurgical/devil-nightly/commit/46f428dac58d039a3e541f55e81d7c0790ec022e#r30517142

I went through and fixed all the names of string-related win32 functions to their regular names since that's how they're normally referenced in source code. If there's evidence to the contrary feel free to reject this.

(Should be cosmetic changes only.)